### PR TITLE
popover for long titles in subcategories added

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-collapsible": "^1.1.0",
         "@radix-ui/react-dialog": "^1.1.1",
         "@radix-ui/react-dropdown-menu": "^2.1.1",
+        "@radix-ui/react-hover-card": "^1.1.2",
         "@radix-ui/react-icons": "^1.3.0",
         "@radix-ui/react-menubar": "^1.1.1",
         "@radix-ui/react-select": "^2.1.1",
@@ -1713,6 +1714,127 @@
         "@radix-ui/react-compose-refs": "1.1.0",
         "@radix-ui/react-primitive": "2.0.0",
         "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.2.tgz",
+      "integrity": "sha512-Y5w0qGhysvmqsIy6nQxaPa6mXNKznfoGjOfBgzOjocLxr2XlSjqBMYQQL+FfyogsMuX+m8cZyQGYhJxvxUzO4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.1",
+        "@radix-ui/react-popper": "1.2.0",
+        "@radix-ui/react-portal": "1.1.2",
+        "@radix-ui/react-presence": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card/node_modules/@radix-ui/react-context": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+      "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.1.tgz",
+      "integrity": "sha512-QSxg29lfr/xcev6kSz7MAlmDnzbP1eI/Dwn3Tp1ip0KT5CUELsxkekFEMVBEoykI3oV39hKT4TKZzBNMbcTZYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.2.tgz",
+      "integrity": "sha512-WeDYLGPxJb/5EGBoedyJbT0MpoULmwnIPMJMSldkuiMsBAv7N1cRdsTWZWht9vpPOiN3qyiGAtbK2is47/uMFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.1.tgz",
+      "integrity": "sha512-IeFXVi4YS1K0wVZzXNrbaaUvIJ3qdY+/Ih4eHFhWA9SwGR9UDX7Ck8abvL57C4cv3wwMvUE0OG69Qc3NCcTe/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-collapsible": "^1.1.0",
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-dropdown-menu": "^2.1.1",
+    "@radix-ui/react-hover-card": "^1.1.2",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-menubar": "^1.1.1",
     "@radix-ui/react-select": "^2.1.1",

--- a/frontend/src/shared/ui/shadcn-ui/hover-card.tsx
+++ b/frontend/src/shared/ui/shadcn-ui/hover-card.tsx
@@ -1,0 +1,27 @@
+import * as React from "react"
+import * as HoverCardPrimitive from "@radix-ui/react-hover-card"
+
+import { cn } from "@/shared/library/utils"
+
+const HoverCard = HoverCardPrimitive.Root
+
+const HoverCardTrigger = HoverCardPrimitive.Trigger
+
+const HoverCardContent = React.forwardRef<
+  React.ElementRef<typeof HoverCardPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <HoverCardPrimitive.Content
+    ref={ref}
+    align={align}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 w-64 rounded-md border border-neutral-200 bg-white p-4 text-neutral-950 shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50",
+      className
+    )}
+    {...props}
+  />
+))
+HoverCardContent.displayName = HoverCardPrimitive.Content.displayName
+
+export { HoverCard, HoverCardTrigger, HoverCardContent }

--- a/frontend/src/widgets/aside-nav/aside-nav.tsx
+++ b/frontend/src/widgets/aside-nav/aside-nav.tsx
@@ -6,6 +6,11 @@ import { Link } from 'react-router-dom'
 import { categoryApi } from '@/entities/category'
 import { CategoryResponse } from '@/entities/category/model/category.types.ts'
 import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from '@/shared/ui/shadcn-ui/hover-card.tsx'
+import {
   Menubar,
   MenubarContent,
   MenubarItem,
@@ -16,6 +21,8 @@ import { Separator } from '@/shared/ui/shadcn-ui/separator'
 import { FacebookIconOutline, InstagramIconOutline } from '@/shared/ui'
 import AsideCategoryLoader from '@/shared/ui/loaders/aside-category.loader.tsx'
 import { QUERY_KEYS } from '@/shared/constants'
+
+const TITLE_LENGTH_THRESHOLD = 20 // Set a threshold for truncation (number of characters)
 
 export const AsideNav = () => {
   const { t, i18n } = useTranslation()
@@ -59,7 +66,7 @@ export const AsideNav = () => {
                       className='h-6 w-6 transition duration-300 ease-in-out focus:brightness-0 focus:invert focus:filter group-hover:brightness-0 group-hover:invert group-hover:filter group-data-[state=open]:brightness-0 group-data-[state=open]:invert group-data-[state=open]:filter'
                     />
                   ) : null}
-                  <p className='flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-start hover:overflow-visible'>
+                  <p className='flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-start'>
                     {cat.title}
                   </p>
                   <ChevronRight />
@@ -72,24 +79,58 @@ export const AsideNav = () => {
                   {cat.children.slice(0, 6).map(sub => (
                     <div key={sub.path} className='max-w-[155px] space-y-5'>
                       <Link to={`/catalog/${sub.path}`}>
-                        <h4 className='overflow-hidden text-ellipsis whitespace-nowrap text-base/[19.36px] font-semibold hover:overflow-visible hover:text-primary-600'>
-                          {sub.title}
-                        </h4>
+                        <HoverCard openDelay={500} closeDelay={0}>
+                          <HoverCardTrigger asChild>
+                            <h4 className='overflow-hidden text-ellipsis whitespace-nowrap text-base/[19.36px] font-semibold hover:text-primary-600'>
+                              {sub.title}
+                            </h4>
+                          </HoverCardTrigger>
+                          {/* Only render HoverCardContent if title length exceeds threshold */}
+                          {sub.title.length > TITLE_LENGTH_THRESHOLD && (
+                            <HoverCardContent
+                              side='top'
+                              className='w-fit bg-gray-50'
+                            >
+                              {sub.title}
+                            </HoverCardContent>
+                          )}
+                        </HoverCard>
                       </Link>
-
                       <ul className='space-y-2.5'>
                         {sub.children.slice(0, 5).map(item => (
                           <li key={item.path}>
                             <Link to={`/catalog/${item.path}`}>
-                              <MenubarItem className='max-w-[155px] cursor-pointer bg-none p-0 text-base/[19.36px] font-normal transition-colors duration-300 focus:text-primary-600'>
-                                <p className='flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-start hover:overflow-visible hover:whitespace-nowrap'>
-                                  {item.title}
-                                </p>
+                              <MenubarItem className='max-w-[155px] cursor-pointer bg-none p-0 text-base/[19.36px] font-normal transition-colors duration-300'>
+                                <HoverCard openDelay={500} closeDelay={0}>
+                                  <HoverCardTrigger asChild>
+                                    <p className='overflow-hidden text-ellipsis whitespace-nowrap hover:text-primary-600'>
+                                      {item.title}
+                                    </p>
+                                  </HoverCardTrigger>
+                                  {/* Only render HoverCardContent if title length exceeds threshold */}
+                                  {item.title.length >
+                                    TITLE_LENGTH_THRESHOLD && (
+                                    <HoverCardContent
+                                      side='top'
+                                      className='w-fit bg-gray-50 hover:text-primary-600'
+                                    >
+                                      {item.title}
+                                    </HoverCardContent>
+                                  )}
+                                </HoverCard>
                               </MenubarItem>
                             </Link>
                           </li>
                         ))}
                       </ul>
+                      <div>
+                        <Link
+                          to={`/catalog/${sub.path}`}
+                          className='rounded-[7px] bg-primary-900 px-[5px] py-[1px] text-xs text-gray-50 transition-colors duration-300 hover:bg-primary-600'
+                        >
+                          Show all
+                        </Link>
+                      </div>
                     </div>
                   ))}
                 </MenubarContent>


### PR DESCRIPTION
### **PR Type**
Enhancement, Dependencies


___

### **Description**
- Introduced a new `HoverCard` component to handle popovers for long subcategory titles using Radix UI.
- Enhanced the aside navigation to display popovers when subcategory titles exceed a defined length threshold.
- Updated project dependencies to include `@radix-ui/react-hover-card` in both `package.json` and `package-lock.json`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hover-card.tsx</strong><dd><code>Introduce HoverCard component for displaying popovers</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/shared/ui/shadcn-ui/hover-card.tsx

<li>Added a new <code>HoverCard</code> component using Radix UI.<br> <li> Implemented <code>HoverCardTrigger</code> and <code>HoverCardContent</code> components.<br> <li> Utilized utility function <code>cn</code> for class name management.<br>


</details>


  </td>
  <td><a href="https://github.com/itsproutorgua/olx-killer-monorepo/pull/12/files#diff-07257e5dc15f2286d6c27fa0f3dbfe47ed870ad7d19034850397ee3035ed6cbc">+27/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>aside-nav.tsx</strong><dd><code>Add popover functionality for long subcategory titles</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/widgets/aside-nav/aside-nav.tsx

<li>Integrated <code>HoverCard</code> for subcategory titles in the navigation.<br> <li> Added logic to display popovers for long titles.<br> <li> Defined a title length threshold for popover activation.<br>


</details>


  </td>
  <td><a href="https://github.com/itsproutorgua/olx-killer-monorepo/pull/12/files#diff-e4bae4ec010dc270766b884e0b1ba54433508f3790d69046d9574bbff757afba">+50/-9</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package-lock.json</strong><dd><code>Update package-lock.json with new Radix UI dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/package-lock.json

<li>Updated dependencies to include <code>@radix-ui/react-hover-card</code>.<br> <li> Added detailed dependency metadata for <code>@radix-ui/react-hover-card</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/itsproutorgua/olx-killer-monorepo/pull/12/files#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62a">+122/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add Radix UI Hover Card to dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/package.json

- Added `@radix-ui/react-hover-card` to project dependencies.



</details>


  </td>
  <td><a href="https://github.com/itsproutorgua/olx-killer-monorepo/pull/12/files#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information