### PR TITLE
Aside nav/popover fixes

### DIFF
--- a/frontend/src/widgets/aside-nav/aside-nav.tsx
+++ b/frontend/src/widgets/aside-nav/aside-nav.tsx
@@ -81,7 +81,7 @@ export const AsideNav = () => {
                       <Link to={`/catalog/${sub.path}`}>
                         <HoverCard openDelay={500} closeDelay={0}>
                           <HoverCardTrigger asChild>
-                            <h4 className='overflow-hidden text-ellipsis whitespace-nowrap text-base/[19.36px] font-semibold hover:text-primary-600'>
+                            <h4 className='overflow-hidden text-ellipsis whitespace-nowrap text-base/[19.36px] font-semibold capitalize hover:text-primary-600'>
                               {sub.title}
                             </h4>
                           </HoverCardTrigger>

--- a/frontend/src/widgets/aside-nav/aside-nav.tsx
+++ b/frontend/src/widgets/aside-nav/aside-nav.tsx
@@ -22,7 +22,7 @@ import { FacebookIconOutline, InstagramIconOutline } from '@/shared/ui'
 import AsideCategoryLoader from '@/shared/ui/loaders/aside-category.loader.tsx'
 import { QUERY_KEYS } from '@/shared/constants'
 
-const TITLE_LENGTH_THRESHOLD = 20 // Set a threshold for truncation (number of characters)
+const TITLE_LENGTH_THRESHOLD = 17 // Set a threshold for truncation (number of characters)
 
 export const AsideNav = () => {
   const { t, i18n } = useTranslation()


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Reduced the title length threshold for truncation in the aside navigation from 20 to 17 characters to improve display consistency.
- Added capitalization to subcategory titles in the aside navigation to enhance readability and presentation.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aside-nav.tsx</strong><dd><code>Enhance aside navigation with truncation and capitalization</code></dd></summary>
<hr>

frontend/src/widgets/aside-nav/aside-nav.tsx

<li>Reduced the title length threshold for truncation from 20 to 17 <br>characters.<br> <li> Added capitalization to subcategory titles in the aside navigation.<br>


</details>


  </td>
  <td><a href="https://github.com/itsproutorgua/olx-killer-monorepo/pull/18/files#diff-e4bae4ec010dc270766b884e0b1ba54433508f3790d69046d9574bbff757afba">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information