### PR TITLE
Fixed message status, fixed chat list returning, renamed field 'username'

### DIFF
--- a/backend/apps/chat/consumers/consumers.py
+++ b/backend/apps/chat/consumers/consumers.py
@@ -17,8 +17,6 @@ class ChatConsumer(AsyncWebsocketConsumer):
         except KeyError:
             raise KeyError('Enter correct query params')
 
-        print(self.scope['room_id'])
-
         # Authenticate user
         self.scope['first_user'] = await UserUtils.authenticate_user(self.scope)
         if not self.scope['first_user']:
@@ -91,6 +89,9 @@ class ChatConsumer(AsyncWebsocketConsumer):
     async def mark_message_as_read(self, message_id):
         await MessageUtils.mark_message_as_read(self, message_id)
 
+    async def send_last_readed_messages(self, event):
+        await MessageUtils.send_last_readed_messages(self, event)
+
     async def get_recipient(self):
         return await UserUtils.get_recipient(self.room, self.scope['first_user'])
 
@@ -99,3 +100,4 @@ class ChatConsumer(AsyncWebsocketConsumer):
 
     async def message_edit(self, event):
         await MessageUtils.message_edit(self, event)
+

--- a/backend/apps/chat/serializers/chat.py
+++ b/backend/apps/chat/serializers/chat.py
@@ -8,14 +8,14 @@ from apps.users.models.profile import Profile
 
 
 class ProfileSerializer(serializers.ModelSerializer):
-    username = serializers.SerializerMethodField()
+    first_name = serializers.SerializerMethodField()
 
     class Meta:
         model = Profile
-        fields = ['id', 'picture', 'username']
+        fields = ['id', 'picture', 'first_name']
 
-    def get_username(self, obj):
-        return obj.user.username
+    def get_first_name(self, obj):
+        return obj.user.first_name
 
 
 class ChatReceiveSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Dispatch read messages with `send_last_readed_messages`

- Mark delivered messages as read if not sender

- Rename `username` field to `first_name` serializer

- Remove debug print for `room_id` on connect


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>consumers.py</strong><dd><code>Add read messages event handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/apps/chat/consumers/consumers.py

<li>Added <code>send_last_readed_messages</code> handler<br> <li> Integrated read receipt dispatch via MessageUtils<br> <li> Removed debug print for <code>room_id</code>


</details>


  </td>
  <td><a href="https://github.com/itsproutorgua/olx-killer-monorepo/pull/124/files#diff-096e671448653588182193496fc3f93dfb9463ca1dc4f32f73cf097e0bb8d392">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chat.py</strong><dd><code>Rename username to first_name in serializer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/apps/chat/serializers/chat.py

<li>Renamed <code>username</code> to <code>first_name</code><br> <li> Updated serializer fields list accordingly


</details>


  </td>
  <td><a href="https://github.com/itsproutorgua/olx-killer-monorepo/pull/124/files#diff-716a3e8c4b68a1ef64d71d75eb6de936721239bed59ef961cbead6b7180bca24">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>messages.py</strong><dd><code>Enhance read receipt and dispatch logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/apps/chat/utils/messages.py

<li>Segregate read vs. pending messages lists<br> <li> Added read receipt list and group send logic<br> <li> Introduced <code>send_last_readed_messages</code> helper


</details>


  </td>
  <td><a href="https://github.com/itsproutorgua/olx-killer-monorepo/pull/124/files#diff-1a7f0314627f6093d635952484a4816cf0cafa1273078ab5e0dc69a24e1a89e3">+16/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>