### PR TITLE
bugs related to editing and prefilling messages fixed

### DIFF
--- a/frontend/src/features/announcement/add-announcement/add-announcement.tsx
+++ b/frontend/src/features/announcement/add-announcement/add-announcement.tsx
@@ -5,7 +5,7 @@ import { AddListingButton } from '@/features/announcement/ui/add-listing-button.
 export const AddAnnouncement = () => {
   const { t } = useTranslation()
   return (
-    <div className='flex max-h-[329px] w-full flex-col items-center rounded-[15px] border border-border/60 pb-[89px] pt-[99px]'>
+    <div className='flex max-h-[329px] w-full max-w-[305px] flex-col items-center rounded-[15px] border border-border/60 pb-[89px] pt-[99px]'>
       <div className='space-y-7'>
         <h2 className='w-[189px] text-[26px]/[28.6px] font-medium'>
           {t('title.announcementTitle')}

--- a/frontend/src/features/chat/ui/message-form.tsx
+++ b/frontend/src/features/chat/ui/message-form.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
 import toast from 'react-hot-toast'
 import { useTranslation } from 'react-i18next'
-import { useLocation } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import TextareaAutosize from 'react-textarea-autosize'
 import { z } from 'zod'
 
@@ -21,55 +21,102 @@ import { useMediaQuery } from '@/shared/library/hooks'
 import { setViewportForIOS } from '@/shared/library/utils/viewportAutozoom.ts'
 
 const FormSchema = z.object({
-  msg: z
-    .string()
-    // .min(1, {
-    //   message: 'Message must be at least 2 characters.',
-    // })
-    .max(500, {
-      message: 'Message must not be longer than 1000 characters.',
-    }),
+  msg: z.string().max(500, {
+    message: 'Message must not be longer than 1000 characters.',
+  }),
 })
 
 export function MessageForm() {
-  const { sendMessage, editMessage, editingMessage, setEditingMessage } =
-    useChatContext()
+  const {
+    sendMessage,
+    editMessage,
+    editingMessage,
+    setEditingMessage,
+    currentRoomId,
+  } = useChatContext()
+
   const { t } = useTranslation()
   const isDesktop = useMediaQuery('(min-width: 1440px)')
   const minRows = isDesktop ? 6 : 1
 
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
+    defaultValues: { msg: '' },
   })
 
   const location = useLocation()
+  const navigate = useNavigate()
   const prefill = location.state?.prefill
 
-  useEffect(() => {
-    if (prefill) {
-      form.setValue('msg', prefill)
-    }
-  }, [prefill])
+  // Track prefill application per room
+  const prefillAppliedRef = useRef<{ roomId: string | null; applied: boolean }>(
+    {
+      roomId: null,
+      applied: false,
+    },
+  )
 
+  // Handle prefill logic
+  useEffect(() => {
+    if (
+      prefill &&
+      !editingMessage &&
+      currentRoomId &&
+      prefillAppliedRef.current.roomId !== currentRoomId
+    ) {
+      form.setValue('msg', prefill)
+      prefillAppliedRef.current = { roomId: currentRoomId, applied: true }
+
+      // Attempt to clear prefill from router state
+      navigate(location.pathname, {
+        replace: true,
+        state: {
+          roomId: currentRoomId,
+          mobileView: location.state?.mobileView,
+        },
+      })
+    }
+  }, [prefill, editingMessage, currentRoomId, location, navigate])
+
+  // Handle edit mode population
   useEffect(() => {
     if (editingMessage) {
       form.setValue('msg', editingMessage.text)
     }
   }, [editingMessage])
 
-  // Viewport meta tag for iOS on mount
+  // Reset form when switching rooms
+  useEffect(() => {
+    // Skip reset if prefill was just applied for the current room
+    if (
+      prefillAppliedRef.current.applied &&
+      prefillAppliedRef.current.roomId === currentRoomId
+    ) {
+      return
+    }
+
+    // Reset form
+    form.reset({ msg: '' })
+    form.setValue('msg', '')
+    if (editingMessage) {
+      setEditingMessage(null)
+    }
+    prefillAppliedRef.current = { roomId: null, applied: false }
+  }, [currentRoomId])
+
+  // iOS viewport fix
   useEffect(() => {
     setViewportForIOS()
   }, [])
 
   const handleSubmit = (data: z.infer<typeof FormSchema>) => {
     const trimmedMsg = data.msg.trim()
+    if (trimmedMsg.length === 0) {
+      toast.error(t('messages.error.emptyEdit'))
+      return
+    }
 
     if (editingMessage) {
-      if (trimmedMsg.length == 0) {
-        toast.error(t('messages.error.emptyEdit'))
-        return
-      }
       editMessage(editingMessage.message_id, trimmedMsg)
       setEditingMessage(null)
     } else {
@@ -77,6 +124,7 @@ export function MessageForm() {
     }
 
     form.reset({ msg: '' })
+    prefillAppliedRef.current = { roomId: null, applied: false }
   }
 
   return (

--- a/frontend/src/pages/layouts/account-root-layout.tsx
+++ b/frontend/src/pages/layouts/account-root-layout.tsx
@@ -6,7 +6,7 @@ import BottomBar from '@/widgets/mobile-bottom-bar/bottom-bar.tsx'
 import { useMediaQuery } from '@/shared/library/hooks'
 
 export const AccountRootLayout = () => {
-  const isMobile = useMediaQuery('(max-width: 767px)')
+  const isMobile = useMediaQuery('(max-width: 1280px)')
   return (
     <div className='grid grid-rows-[_auto_1fr] xl:min-h-screen'>
       <Header />


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Limit announcement panel width.

- Manage chat form prefill per room.

- Reset and clear message form state.

- Update mobile breakpoint threshold.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>add-announcement.tsx</strong><dd><code>Constrain announcement panel width</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/features/announcement/add-announcement/add-announcement.tsx

- Added max-w-[305px] constraint to container.


</details>


  </td>
  <td><a href="https://github.com/itsproutorgua/olx-killer-monorepo/pull/137/files#diff-f100e542cce40689bc845ebe598be24a933bd5f05ebd918eb13eb799499e4b5d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>message-form.tsx</strong><dd><code>Enhance chat form prefill and reset behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/features/chat/ui/message-form.tsx

<li>Added default form values for message.<br> <li> Implemented per-room prefill logic.<br> <li> Reset form and clear edit state on room switch.<br> <li> Trim messages and block empty submissions.


</details>


  </td>
  <td><a href="https://github.com/itsproutorgua/olx-killer-monorepo/pull/137/files#diff-44d3090f61850c981e8b2251d4d082e4f76ed65c81d1b2e59ae3ad168ffd9d7e">+67/-19</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>account-root-layout.tsx</strong><dd><code>Adjust account layout breakpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/layouts/account-root-layout.tsx

- Updated isMobile media query breakpoint to 1280px.


</details>


  </td>
  <td><a href="https://github.com/itsproutorgua/olx-killer-monorepo/pull/137/files#diff-5b98ab9795ec57abf031b3ebbc786e5f662bee9f755f4899e9da2675b587fb76">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>